### PR TITLE
fix(python3.7): Remove python 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# This Dockerfile sets up a Python environment with multiple versions (3.7-3.13) using `uv` under a non-root user.
+# This Dockerfile sets up a Python environment with multiple versions (3.8-3.14) using `uv` under a non-root user.
 # It installs the necessary Python versions, sets the PATH, and installs `tox` for testing workflows.
 
 FROM python:3.13-slim-bookworm
@@ -6,7 +6,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 # Define user variable and Python versions variable
 ARG CI_USER=ciuser
-ARG PYTHON_VERSIONS="3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14"
+ARG PYTHON_VERSIONS="3.8 3.9 3.10 3.11 3.12 3.13 3.14"
 
 # Create a non-root user and configure the environment
 RUN useradd -m -s /bin/bash $CI_USER

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Multi-Python Tox Testing with Docker and uv
 
 This repository demonstrates how to set up a Docker-based testing environment that installs multiple Python versions
-(3.7–3.14) using [uv](https://github.com/astral-sh/uv) and runs tests on all these versions via
+(3.8–3.14) using [uv](https://github.com/astral-sh/uv) and runs tests on all these versions via
 [tox](https://tox.readthedocs.io/) with the [tox-uv](https://github.com/astral-sh/uv) plugin.
 
 ## Project Overview
@@ -10,7 +10,7 @@ The project includes:
 
 - A **Dockerfile** that creates a lightweight container based on `python:3.13-slim-bookworm`:
   - Installs `uv` to manage multiple Python versions.
-  - Installs Python versions 3.7 to 3.14 in `/home/ciuser/.local/bin`.
+  - Installs Python versions 3.8 to 3.14 in `/home/ciuser/.local/bin`.
   - Sets up a non-root user (`ciuser`) and configures the environment.
   - Installs `tox` and the `tox-uv` plugin for multi-Python testing.
 - A **tox.ini** file that configures tox to run tests in environments for all the specified Python versions.
@@ -46,11 +46,11 @@ project-root/
    - Setting the default command to run `tox`.
 
 2. **tox.ini**:  
-   Located in the `tests/` directory, this file defines the environments for Python 3.7 through 3.14:
+   Located in the `tests/` directory, this file defines the environments for Python 3.8 through 3.14:
 
    ```ini
    [tox]
-   envlist = py37,py38,py39,py310,py311,py312,py313,py314
+   envlist = py38,py39,py310,py311,py312,py313,py314
 
    [testenv]
    deps = pytest
@@ -117,7 +117,7 @@ docker run --rm -it -v "$(pwd):/work" --workdir /work ghcr.io/codesquadnest/mult
 rm -rf .tox
 ```
 
-If everything is set up correctly, you should see output from tox running tests in environments for Python 3.7 through 3.14.
+If everything is set up correctly, you should see output from tox running tests in environments for Python 3.8 through 3.14.
 
 ## Contributing
 

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,py311,py312,py313,py314
+envlist = py38,py39,py310,py311,py312,py313,py314
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
latest versions of uv no longer support Python3.7
It's still possible to use it by selecting a previous docker version or an hardcoded version od uv Docker image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to indicate that Python 3.7 is no longer supported; supported versions are now Python 3.8 through 3.14.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->